### PR TITLE
Fix leaderboard

### DIFF
--- a/backend/api/serializer.py
+++ b/backend/api/serializer.py
@@ -167,3 +167,7 @@ class ProfileLeaderboardSerializer(serializers.ModelSerializer):
 class ProfileLeaderboardTimedSerializer(serializers.Serializer):
 	id = serializers.IntegerField()
 	xp = serializers.IntegerField() 
+
+class LeaderboardSerializer(serializers.Serializer):
+	users = ProfileLeaderboardTimedSerializer(many=True)
+	length = serializers.IntegerField()

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -21,7 +21,7 @@ urlpatterns = [
 	path("xpevents/<int:id>", XPEventsAPI.as_view()),
 	path("subject/<str:subject>", SubjectAPI.as_view()),
 	path("leaderboard/", Leaderboard.as_view()),
-	path("leaderboard/<str:time>", Leaderboard.as_view()),
+	path("leaderboard/<str:time>/<int:page>", Leaderboard.as_view()),
 	path("follow/<int:id>", Follow.as_view()),
 	path("email-confirm/<str:username>/<int:code>", VerifyEmailView.as_view())
 ]

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -23,5 +23,6 @@ urlpatterns = [
 	path("leaderboard/", Leaderboard.as_view()),
 	path("leaderboard/<str:time>/<int:page>", Leaderboard.as_view()),
 	path("follow/<int:id>", Follow.as_view()),
-	path("email-confirm/<str:username>/<int:code>", VerifyEmailView.as_view())
+	path("email-confirm/<str:username>/<int:code>", VerifyEmailView.as_view()),
+	path("users/", Users.as_view()),
 ]

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -400,9 +400,14 @@ class Leaderboard(APIView):
 				if i.id == userID: return i
 
 
-		if time == None:
+		if time == "alltime":
 			users = Profile.objects.order_by("-xp__xp")
-			return Response(ProfileLeaderboardSerializer(users, many=True).data)
+
+			# Creates an XPProfile object for each user 
+			formated_users = [self.XPProfile(i.id, i.xp.xp) for i in users]
+
+			return Response(ProfileLeaderboardTimedSerializer(formated_users, many=True).data)
+			
 		elif time == "month":
 			date = datetime.date.today() - datetime.timedelta(days=30)
 		elif time == "day":

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -401,7 +401,7 @@ class Leaderboard(APIView):
 
 
 		if time == None:
-			users = Profile.objects.order_by("xp__xp")
+			users = Profile.objects.order_by("-xp__xp")
 			return Response(ProfileLeaderboardSerializer(users, many=True).data)
 		elif time == "month":
 			date = datetime.date.today() - datetime.timedelta(days=30)
@@ -430,6 +430,8 @@ class Leaderboard(APIView):
 						usersXP.append(self.XPProfile(user.id, event.amount))
 					else:
 						getXPProfile(usersXP, user.id).xp += event.amount
+
+		usersXP.sort(key=lambda x: x.xp, reverse=True)
 
 		return Response(ProfileLeaderboardTimedSerializer(usersXP, many=True).data)
 

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -487,3 +487,12 @@ class VerifyEmailView(APIView):
 			return Response({'detail': 'ok'}, status=status.HTTP_200_OK)
 		
 		return Response({'detail': 'wrong code'}, status=status.HTTP_400_BAD_REQUEST)
+
+
+class Users(APIView):
+	permission_classes = [IsAuthenticated]
+
+	def get(self, request):
+		number_of_users = User.objects.count()
+
+		return Response(number_of_users, status=status.HTTP_200_OK)

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -407,7 +407,7 @@ class Leaderboard(APIView):
 			users = Profile.objects.order_by("-xp__xp")
 
 			# Creates an XPProfile object for each user 
-			formated_users = [self.XPProfile(i.id, i.xp.xp) for i in users[start_position:end_position + 1]]
+			formated_users = [self.XPProfile(i.id, i.xp.xp) for i in users[start_position:end_position]]
 
 			return Response(ProfileLeaderboardTimedSerializer(formated_users, many=True).data)
 

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -403,14 +403,21 @@ class Leaderboard(APIView):
 		start_position = (page - 1) * LEADERBOARD_PAGE_SIZE
 		end_position = page * LEADERBOARD_PAGE_SIZE
 
+		# Alltime leaderboard
 		if time == "alltime":
 			users = Profile.objects.order_by("-xp__xp")
 
 			# Creates an XPProfile object for each user 
 			formated_users = [self.XPProfile(i.id, i.xp.xp) for i in users[start_position:end_position]]
 
-			return Response(ProfileLeaderboardTimedSerializer(formated_users, many=True).data)
+			leaderboard = {
+				"users": formated_users,
+				"length": Profile.objects.count()
+			}
 
+			return Response(LeaderboardSerializer(leaderboard).data)
+
+		# Leaderboards with time span
 		elif time == "month":
 			date = datetime.date.today() - datetime.timedelta(days=30)
 		elif time == "day":
@@ -441,7 +448,12 @@ class Leaderboard(APIView):
 
 		usersXP.sort(key=lambda x: x.xp, reverse=True)
 
-		return Response(ProfileLeaderboardTimedSerializer(usersXP, many=True).data)
+		leaderboard = {
+			"users": usersXP,
+			"length": len(users)
+		}
+
+		return Response(LeaderboardSerializer(leaderboard).data)
 
 
 class Follow(APIView):

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -199,8 +199,8 @@ export async function getAllAchievements(successCall) {
 }
 
 
-export async function fetchLeaderboard(span, successCall) {
-	axios.get("api/leaderboard/" + span)
+export async function fetchLeaderboard(span, page, successCall) {
+	axios.get("api/leaderboard/" + span + "/" + page)
 	.then((res) => successCall(res));
 }
 

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -238,3 +238,8 @@ export async function confirmEmail(code, username, successCall, errorCall) {
 	.then((res) => successCall(res))
 	.catch((error) => errorCall(error));
 }
+
+export async function getNumberOfUsers(successCall) {
+	axios.get("api/users/")
+	.then((res) => successCall(res));
+}

--- a/frontend/src/components/profile/LeaderboardBar.js
+++ b/frontend/src/components/profile/LeaderboardBar.js
@@ -24,7 +24,7 @@ const useStyles = makeStyles(theme => ({
 }))
 
 // TODO: Include user's streak
-function LeaderboardBar({id, place, page}) {
+function LeaderboardBar({id, xp, place, page}) {
     const [profile, setProfile] = useState();
     const [loading, setLoading] = useState(true);
     const position = page * 10 + place
@@ -52,7 +52,7 @@ function LeaderboardBar({id, place, page}) {
                 <Typography>{profile.user.username}</Typography>
             </Grid>     
             <Grid className={classes.xp}>
-                <Typography>{profile.xp.xp} XP</Typography>
+                <Typography>{xp} XP</Typography>
             </Grid>
         </Grid>
     )

--- a/frontend/src/pages/LeaderboardPage.js
+++ b/frontend/src/pages/LeaderboardPage.js
@@ -48,12 +48,14 @@ function LeaderboardPage() {
     const [open, setOpen] = useState(false);
     const [loading, setLoading] = useState(true);
     const [page, setPage] = useState(1);
+    const [numberOfPages, setNumberOfPages] = useState();
 
     const classes = useStyles();
 
     useEffect(() => {
         fetchLeaderboard(TO_ENGLISH[span], page, (res) => {
-            setLeaderboard(res.data);
+            setLeaderboard(res.data.users);
+            setNumberOfPages(res.data.length > USERS_PER_PAGE ? Math.ceil(res.data.length / USERS_PER_PAGE) : 1)
             setLoading(false);
         })
     }, [span, page])
@@ -77,6 +79,10 @@ function LeaderboardPage() {
         setPage(value);
     }
 
+    const renderLeaderboard = leaderboard.map((user, index) => (
+            <LeaderboardBar key={user.id} id={user.id} xp={user.xp} place={index + 1} page={page - 1}/>
+        ));
+
     return (
         <Paper className={classes.panel}>
             <Typography variant='h4' className={classes.title}>
@@ -92,17 +98,13 @@ function LeaderboardPage() {
                     className={classes.dropdown}
                 >   
                     {SPANS.map((span) => (
-                        <MenuItem value={span}>{span}</MenuItem>
+                        <MenuItem key={span} value={span}>{span}</MenuItem>
                     ))}
                 </Select>
             </Typography>
 
             <Grid container>
-                {leaderboard
-                .slice(USERS_PER_PAGE * (page - 1), USERS_PER_PAGE * page)
-                .map((user, index) => (
-                    <LeaderboardBar key={user.id} id={user.id} xp={user.xp} place={index + 1} page={page - 1}/>
-                ))}
+                {renderLeaderboard}
             </Grid> 
 
             <Grid container justifyContent='center' className={classes.pagination}>
@@ -110,7 +112,7 @@ function LeaderboardPage() {
                     onChange={pageChange}
                     defaultPage={1}
                     color='secondary' 
-                    count={leaderboard.length > USERS_PER_PAGE ? Math.ceil(leaderboard.length / USERS_PER_PAGE) : 1}/>
+                    count={numberOfPages}/>
             </Grid>
         </Paper>
     );

--- a/frontend/src/pages/LeaderboardPage.js
+++ b/frontend/src/pages/LeaderboardPage.js
@@ -8,9 +8,9 @@ import globalTheme from '../globalTheme';
 import Pagination from '@mui/material/Pagination';
 
 const SPANS = [
+    "sempre",
     "mês",
-    "dia",
-    "sempre"
+    "dia"
 ]
 
 const TO_ENGLISH = {
@@ -44,7 +44,7 @@ const useStyles = makeStyles(theme => ({
 
 function LeaderboardPage() {
     const [leaderboard, setLeaderboard] = useState([]);
-    const [span, setSpan] = useState("mês");
+    const [span, setSpan] = useState("sempre");
     const [open, setOpen] = useState(false);
     const [loading, setLoading] = useState(true);
     const [page, setPage] = useState(1);
@@ -86,7 +86,7 @@ function LeaderboardPage() {
     return (
         <Paper className={classes.panel}>
             <Typography variant='h4' className={classes.title}>
-                Leaderboard do <span/>
+                Leaderboard {span === "sempre" ? "de" : "do"} <span/>
                 <Select
                     labelId="demo-controlled-open-select-label"
                     id="demo-controlled-open-select"

--- a/frontend/src/pages/LeaderboardPage.js
+++ b/frontend/src/pages/LeaderboardPage.js
@@ -9,12 +9,14 @@ import Pagination from '@mui/material/Pagination';
 
 const SPANS = [
     "mês",
-    "dia"
+    "dia",
+    "sempre"
 ]
 
 const TO_ENGLISH = {
     "mês": "month",
-    "dia": "day"
+    "dia": "day",
+    "sempre": "alltime"
 }
 
 const USERS_PER_PAGE = 10
@@ -50,11 +52,11 @@ function LeaderboardPage() {
     const classes = useStyles();
 
     useEffect(() => {
-        fetchLeaderboard(TO_ENGLISH[span], (res) => {
+        fetchLeaderboard(TO_ENGLISH[span], page, (res) => {
             setLeaderboard(res.data);
             setLoading(false);
         })
-    }, [span])
+    }, [span, page])
 
     if (loading) return <Loading />
 
@@ -99,7 +101,7 @@ function LeaderboardPage() {
                 {leaderboard
                 .slice(USERS_PER_PAGE * (page - 1), USERS_PER_PAGE * page)
                 .map((user, index) => (
-                    <LeaderboardBar key={user.id} id={user.id} place={index + 1} page={page - 1}/>
+                    <LeaderboardBar key={user.id} id={user.id} xp={user.xp} place={index + 1} page={page - 1}/>
                 ))}
             </Grid> 
 


### PR DESCRIPTION
Changes:

- Delete specific leaderboard endpoint for `alltime`
- Uniformize `alltime` response to the rest of the leaderboards
- Change leaderboard API response  to include length of the leaderboard
- Sorte users by XP
- Fix the XP gained during the requested period
- Add paging for performance reasons 

Closes #115 #117 