### PR TITLE
Hotfix 1.0.1 🔧 - Fix misaligned `Profile` and `User` id

### DIFF
--- a/backend/api/serializer.py
+++ b/backend/api/serializer.py
@@ -14,11 +14,14 @@ class UserSerializer(serializers.ModelSerializer):
 	username = serializers.ReadOnlyField()
 	mod = serializers.BooleanField(source="is_staff")
 	admin = serializers.BooleanField(source="is_superuser")
+	profile = serializers.IntegerField(source='profile.id')
 
 	class Meta:
 		model = User
-		fields = ("id", "username", "email", "mod", "admin")
+		fields = ("id", "profile", "username", "email", "mod", "admin")
 
+	def get_profile(self):
+		profile = Profile.objects.get(user=self.id)
 
 class XPEventSerializer(serializers.ModelSerializer):
 	class Meta:

--- a/frontend/src/pages/ProfilePage.js
+++ b/frontend/src/pages/ProfilePage.js
@@ -27,8 +27,8 @@ const ProfilePage = () => {
 
 	useEffect(() => {
 		getUser((res1) => {
-			getProfile(res1.data.id, (res2) => {
-				getXpEvents(res1.data.id, (res3) => {
+			getProfile(res1.data.profile, (res2) => {
+				getXpEvents(res1.data.profile, (res3) => {
 					setXpEvents(res3.data);
 					setLoading(false);
 				});


### PR DESCRIPTION
This PR solves the problem of when the profile and user id get misaligned. The problem happened when we considered them to always be equal, fact that for some reason isn't true.