### PR TITLE
Hotfix 1.0.2 🔧 Fix recommended exam

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "frontend",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"private": true,
 	"scripts": {
 		"start": "react-scripts start",


### PR DESCRIPTION
The exam was being created without checking query lengths and was throwing an error when the user didn't have enough wrong answered questions and correct answered questions (ex.: first exam ever).