### PR TITLE
Fix 🔧 Email Reset Route Order

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -75,12 +75,12 @@ function App() {
 											/>
 											<AuthRoute path='/perfil' component={ProfilePage} />
 											<Route
-												path='/password/reset'
-												component={PasswordResetPage}
-											/>
-											<Route
 												path='/password/reset/confirm/:uid/:token'
 												component={PasswordResetConfirmPage}
+											/>
+											<Route
+												path='/password/reset'
+												component={PasswordResetPage}
 											/>
 											<AuthRoute
 												path='/configuracoes'


### PR DESCRIPTION
The problem was in `/password/reset/confirm/` being first in the router, causing react router to choose it instead of `/password/reset/confirm/<code>/<code>`.
Closes #233 