### PR TITLE
Add Makefile

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,23 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[Bug]"
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[Feature]"
+labels: feature
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,9 +6,11 @@ on:
   push:
     branches:
       - main
+      - develop
   pull_request:
     branches:
       - main
+      - develop
 
 jobs:
   run-linters:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+all: clean deploy logs
+
+build:
+	docker compose -f docker-compose.yml -f docker-compose.override.yml build
+
+deploy:
+	docker compose -f docker-compose.yml -f docker-compose.override.yml up -d
+
+logs:
+	docker compose logs -f
+
+logs-backend:
+	docker logs -f backend-dev
+
+logs-frontend:
+	docker logs -f frontend-dev
+
+shell-backend:
+	docker exec -it backend-dev /bin/bash
+
+clean:
+	docker compose -f docker-compose.yml -f docker-compose.override.yml down --remove-orphans


### PR DESCRIPTION
This PR adds a new Makefile to help development by abstracting the docker commands into simpler ones.

- `make build`: to build the project
- `make deploy`: to deploy the project
- `make clean`: to clean all the running containers
- `make shell-backend`: to enter the shell of the backend container
- `make logs`: to access containers logs
- `make logs-backend`: to access backend logs
- `make logs-frontend`: to access frontend logs
- `make`: to clean, deploy and access logs in one command

Closes #268 